### PR TITLE
Allow zero probability

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,8 @@
 var randomGenerator = require('random-seed');
 
 var cleanScore = function (score) {
-	var num = parseFloat(score) || 1;
+	var num = score === undefined ? 1 : parseFloat(score);
+	num = isNaN(num) ? 1 : num;
 	if (!Number.isFinite(num) || num < 0) {
 		num = 0;
 	}

--- a/test.js
+++ b/test.js
@@ -79,4 +79,12 @@ describe('random-picker', function () {
 			expect(['male', 'female'].indexOf(picker.pick())).to.be.within(0, 1);
 		}
 	});
+	it('should work with zero as option value', function () {
+		picker.option('male', 0);
+		picker.option('female', 1);
+		expect(picker.totalScore()).to.be.equal(1);
+		for (i = 0; i < iterations; i++) {
+			expect(['male', 'female'].indexOf(picker.pick())).to.be.equal(1);
+		}
+	});
 });


### PR DESCRIPTION
This allows for:

```js
picker.option('name', 0)
```

Might also want to look into the logic here:

```js
if (!Number.isFinite(num) || num < 0) {
  num = 0;
}
```

If a number is infinity, one would not want the probability to be zero.

Fixes issue #3